### PR TITLE
Add Logic to set as Entire Site and Notice Error [TMZ-378]

### DIFF
--- a/modules/template-parts/components/document.php
+++ b/modules/template-parts/components/document.php
@@ -47,15 +47,54 @@ class Document {
 		}
 	}
 
-
 	public function register_remote_source() {
 		Utils::elementor()->templates_manager->register_source(
 			'HelloPlus\Modules\TemplateParts\Classes\Sources\Source_Remote_Ehp'
 		);
 	}
 
+	public function maybe_set_as_entire_site() {
+		$action = sanitize_key( filter_input( INPUT_GET, 'action' ) );
+
+		switch ( $action ) {
+			case 'hello_plus_set_as_entire_site':
+				$post = filter_input( INPUT_GET, 'post', FILTER_VALIDATE_INT );
+				check_admin_referer( 'hello_plus_set_as_entire_site_' . $post );
+
+				$redirect_to = filter_input( INPUT_GET, 'redirect_to', FILTER_SANITIZE_URL );
+
+				$document = Utils::elementor()->documents->get( $post );
+
+				if ( ! $document instanceof \HelloPlus\Modules\TemplateParts\Documents\Ehp_Document_Base ) {
+					return;
+				}
+
+				$class_name = get_class( $document );
+				$post_ids = $class_name::get_all_document_posts( [ 'posts_per_page' => -1 ] );
+
+				foreach ( $post_ids as $post_id ) {
+					wp_update_post( [
+						'ID' => $post_id,
+						'post_status' => 'draft',
+					] );
+				}
+
+				wp_update_post( [
+					'ID' => $post,
+					'post_status' => 'publish',
+				] );
+
+				wp_safe_redirect( $redirect_to );
+
+				exit;
+			default:
+				break;
+		}
+	}
+
 	public function __construct() {
 		add_action( 'elementor/documents/register', [ $this, 'register' ] );
 		add_action( 'elementor/init', [ $this, 'register_remote_source' ] );
+		add_action( 'admin_init', [ $this, 'maybe_set_as_entire_site' ] );
 	}
 }

--- a/modules/template-parts/documents/ehp-document-base.php
+++ b/modules/template-parts/documents/ehp-document-base.php
@@ -90,8 +90,8 @@ abstract class Ehp_Document_Base extends Library_Document {
 				'<a href="?post=%s&action=hello_plus_set_as_entire_site&_wpnonce=%s&redirect_to=%s">%s</a>',
 				$this->get_post()->ID,
 				wp_create_nonce( 'hello_plus_set_as_entire_site_' . $this->get_post()->ID ),
-				urlencode( add_query_arg( null, null ) ),
-				esc_html__( 'Set as Entire Site', 'elementor' )
+				rawurlencode( add_query_arg( null, null ) ),
+				esc_html__( 'Set as Entire Site', 'hello-plus' )
 			);
 		}
 
@@ -176,13 +176,13 @@ abstract class Ehp_Document_Base extends Library_Document {
 	public static function maybe_display_notice() {
 		$posts = static::get_all_document_posts();
 
-		if ( count( $posts ) > 1  && 'edit-elementor_library' === get_current_screen()->id ) {
+		if ( count( $posts ) > 1 && 'edit-elementor_library' === get_current_screen()->id ) {
 			$admin_notices = Utils::elementor()->admin->get_component( 'admin-notices' );
 
 			$options = [
-				'title' => sprintf( esc_html__( 'More than one %s published.', 'elementor' ), static::get_title() ),
+				'title' => sprintf( esc_html__( 'More than one %s published.', 'hello-plus' ), static::get_title() ),
 				'description' => sprintf(
-					esc_html__( 'We noticed that you have more than one %s published. This is an issue that will prevent it from rendering on the front end', 'elementor' ),
+					esc_html__( 'We noticed that you have more than one %s published. This is an issue that will prevent it from rendering on the front end', 'hello-plus' ),
 					static::get_title(),
 				),
 				'type' => 'error',

--- a/modules/template-parts/module.php
+++ b/modules/template-parts/module.php
@@ -3,7 +3,6 @@
 namespace HelloPlus\Modules\TemplateParts;
 
 use Elementor\Controls_Manager;
-use Hamcrest\Util;
 use HelloPlus\Includes\Module_Base;
 use HelloPlus\Includes\Utils;
 use HelloPlus\Modules\TemplateParts\Classes\Control_Media_Preview;
@@ -123,38 +122,5 @@ class Module extends Module_Base {
 		add_action( 'elementor/editor/after_enqueue_styles', [ $this, 'enqueue_editor_styles' ] );
 		add_action( 'elementor/editor/before_enqueue_scripts', [ $this, 'enqueue_editor_scripts' ] );
 		add_action( 'elementor/controls/register', [ $this, 'register_controls' ] );
-		add_action( 'admin_init', function () {
-			$action = sanitize_key( filter_input( INPUT_GET, 'action' ) );
-
-			switch ( $action ) {
-				case 'hello_plus_set_as_entire_site':
-					$post = filter_input( INPUT_GET, 'post', FILTER_VALIDATE_INT );
-					check_admin_referer( 'hello_plus_set_as_entire_site_' . $post );
-
-					$redirect_to = filter_input( INPUT_GET, 'redirect_to', FILTER_SANITIZE_URL );
-
-					$document = Utils::elementor()->documents->get( $post );
-					$class_name = get_class( $document );
-					$post_ids = $class_name::get_all_document_posts( [ 'posts_per_page' => -1 ] );
-
-					foreach ( $post_ids as $post_id ) {
-						wp_update_post( [
-							'ID' => $post_id,
-							'post_status' => 'draft',
-						] );
-					}
-
-					wp_update_post( [
-						'ID' => $post,
-						'post_status' => 'publish',
-					] );
-
-					wp_safe_redirect( $redirect_to );
-
-					exit;
-				default:
-					break;
-			}
-		} );
 	}
 }

--- a/modules/template-parts/module.php
+++ b/modules/template-parts/module.php
@@ -123,7 +123,7 @@ class Module extends Module_Base {
 		add_action( 'elementor/editor/after_enqueue_styles', [ $this, 'enqueue_editor_styles' ] );
 		add_action( 'elementor/editor/before_enqueue_scripts', [ $this, 'enqueue_editor_scripts' ] );
 		add_action( 'elementor/controls/register', [ $this, 'register_controls' ] );
-		add_action( 'admin_init', function() {
+		add_action( 'admin_init', function () {
 			$action = sanitize_key( filter_input( INPUT_GET, 'action' ) );
 
 			switch ( $action ) {
@@ -132,11 +132,11 @@ class Module extends Module_Base {
 					check_admin_referer( 'hello_plus_set_as_entire_site_' . $post );
 
 					$redirect_to = filter_input( INPUT_GET, 'redirect_to', FILTER_SANITIZE_URL );
-					error_log( $redirect_to );
 
 					$document = Utils::elementor()->documents->get( $post );
 					$class_name = get_class( $document );
 					$post_ids = $class_name::get_all_document_posts( [ 'posts_per_page' => -1 ] );
+
 					foreach ( $post_ids as $post_id ) {
 						wp_update_post( [
 							'ID' => $post_id,


### PR DESCRIPTION
 - Visually show what is the Active Header or Footer
 - Allow setting as entire site
 - Show warning when more than one header or footer is published