### PR TITLE
Header: Menu cart logic [TMZ-558]

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -53,10 +53,6 @@ class Utils {
 		return defined( 'EHP_THEME_SLUG' ) && ( 'hello-elementor' === EHP_THEME_SLUG );
 	}
 
-	public static function has_hello_commerce_theme(): bool {
-		return defined( 'EHP_THEME_SLUG' ) && ( 'hello-commerce' === EHP_THEME_SLUG );
-	}
-
 	public static function is_elementor_active(): bool {
 		if ( null === self::$elementor_active ) {
 			self::$elementor_active = defined( 'ELEMENTOR_VERSION' );

--- a/modules/template-parts/classes/render/widget-header-render.php
+++ b/modules/template-parts/classes/render/widget-header-render.php
@@ -45,7 +45,7 @@ class Widget_Header_Render {
 		$behavior_scale_logo = $this->settings['behavior_sticky_scale_logo'];
 		$behavior_scale_title = $this->settings['behavior_sticky_scale_title'];
 		$has_blur_background = $this->settings['blur_background'];
-		$has_menu_cart = $this->settings['menu_cart_icon_show'];
+		$has_menu_cart = $this->settings['menu_cart_icon_show'] ?? '';
 
 		if ( ! empty( $navigation_breakpoint ) ) {
 			$this->widget->add_render_attribute( 'layout', [
@@ -221,7 +221,7 @@ class Widget_Header_Render {
 
 	private function render_menu_toggle() {
 		$show_contact_buttons = 'yes' === $this->settings['contact_buttons_show'] || 'yes' === $this->settings['contact_buttons_show_connect'];
-		$has_menu_cart = $this->settings['menu_cart_icon_show'];
+		$has_menu_cart = $this->settings['menu_cart_icon_show'] ?? '';
 
 		$this->widget->add_render_attribute( 'side-toggle', 'class', self::LAYOUT_CLASSNAME . '__side-toggle' );
 		?>
@@ -325,7 +325,7 @@ class Widget_Header_Render {
 				$this->render_button( 'primary' );
 			}
 
-			if ( 'yes' === $this->settings['menu_cart_icon_show'] ) {
+			if ( isset( $this->settings['menu_cart_icon_show'] ) && 'yes' === $this->settings['menu_cart_icon_show'] ) {
 				$this->render_menu_cart();
 			}
 			?>

--- a/modules/template-parts/widgets/ehp-header.php
+++ b/modules/template-parts/widgets/ehp-header.php
@@ -101,7 +101,7 @@ class Ehp_Header extends Ehp_Widget_Base {
 		$this->add_content_site_logo_section();
 		$this->add_content_navigation_section();
 		$this->add_content_contact_buttons_section();
-		if ( Utils::has_hello_commerce_theme() ) {
+		if ( current_theme_supports( 'hello-plus-menu-cart' ) ) {
 			$this->add_content_menu_cart_section();
 		}
 		$this->add_content_cta_section();
@@ -112,7 +112,7 @@ class Ehp_Header extends Ehp_Widget_Base {
 		$this->add_style_navigation_section();
 		$this->add_style_contact_button_section();
 		$this->add_style_cta_section();
-		if ( Utils::has_hello_commerce_theme() ) {
+		if ( current_theme_supports( 'hello-plus-menu-cart' ) ) {
 			$this->add_style_menu_cart_section();
 		}
 		$this->add_style_box_section();


### PR DESCRIPTION
This PR changes the logic with which we do the check to decide if the theme should show the cart or not. The feature is inactive by default, and the theme can activate it by using:
```
add_theme_support( 'hello-plus-menu-cart' );
```

The PR also fixes some PHP warnings when the feature is inactive. 
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Refactor theme detection for menu cart functionality by replacing a dedicated HelloPlus theme function with WordPress theme support checking.

Main changes:
- Removed Utils::has_hello_commerce_theme() utility function that checked for a specific theme slug
- Modified header widget to use current_theme_supports('hello-plus-menu-cart') for feature detection
- Added null coalescing operators for menu_cart_icon_show settings to avoid undefined variable warnings

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
