### PR TITLE
Internal: Allow widget editing on elementor domain [TMZ-739]

### DIFF
--- a/modules/template-parts/assets/js/editor/module.js
+++ b/modules/template-parts/assets/js/editor/module.js
@@ -31,7 +31,7 @@ export default class TemplatesModule extends elementorModules.editor.utils.Modul
 			'library' === component.getNamespace() &&
 			'library/templates/ehp-elements' === component?.defaultRoute
 		) {
-			return () => { };
+			return () => {};
 		}
 		return close;
 	}

--- a/modules/template-parts/assets/js/editor/module.js
+++ b/modules/template-parts/assets/js/editor/module.js
@@ -59,10 +59,12 @@ export default class TemplatesModule extends elementorModules.editor.utils.Modul
 	}
 
 	redirectToHelloPlus() {
-		if ( this.notElementorDomain() ) {
-			$e.internal( 'document/save/set-is-modified', { status: false } );
-			window.location.href = elementor.config.close_modal_redirect_hello_plus + elementor.config.document.type;
+		if ( ! this.notElementorDomain() ) {
+			return;
 		}
+
+		$e.internal( 'document/save/set-is-modified', { status: false } );
+		window.location.href = elementor.config.close_modal_redirect_hello_plus + elementor.config.document.type;
 	}
 
 	async openSiteIdentity() {

--- a/modules/template-parts/assets/js/editor/module.js
+++ b/modules/template-parts/assets/js/editor/module.js
@@ -2,15 +2,15 @@ import Component from './component';
 
 export default class TemplatesModule extends elementorModules.editor.utils.Module {
 	onElementorInit() {
-		$e.components.register( new Component( { manager: this } ) );
-		elementor.channels.editor.on( 'helloPlusLogo:change', this.openSiteIdentity );
-		elementor.hooks.addFilter( 'elements/widget/controls/common/default', this.resetCommonControls.bind( this ) );
-		elementor.hooks.addFilter( 'elements/widget/controls/common-optimized/default', this.resetCommonControls.bind( this ) );
-		elementor.hooks.addFilter( 'templates/source/is-remote', this.setSourceAsRemote.bind( this ) );
-		elementor.hooks.addFilter( 'elements/base/behaviors', this.filterBehviors.bind( this ), 1000 );
+		$e.components.register(new Component({ manager: this }));
+		elementor.channels.editor.on('helloPlusLogo:change', this.openSiteIdentity);
+		elementor.hooks.addFilter('elements/widget/controls/common/default', this.resetCommonControls.bind(this));
+		elementor.hooks.addFilter('elements/widget/controls/common-optimized/default', this.resetCommonControls.bind(this));
+		elementor.hooks.addFilter('templates/source/is-remote', this.setSourceAsRemote.bind(this));
+		elementor.hooks.addFilter('elements/base/behaviors', this.filterBehviors.bind(this), 1000);
 		elementor.hooks.addFilter(
 			'component/modal/close',
-			this.preventClosingModal.bind( this ),
+			this.preventClosingModal.bind(this),
 			1000,
 		);
 
@@ -19,39 +19,39 @@ export default class TemplatesModule extends elementorModules.editor.utils.Modul
 			'core/modal/close/ehp-header',
 		];
 
-		types.forEach( ( type ) => {
-			window.addEventListener( type, this.redirectToHelloPlus );
-		} );
+		types.forEach((type) => {
+			window.addEventListener(type, this.redirectToHelloPlus);
+		});
 
 		window.templatesModule = this;
 	}
 
-	preventClosingModal( close, component ) {
+	preventClosingModal(close, component) {
 		if (
 			'library' === component.getNamespace() &&
 			'library/templates/ehp-elements' === component?.defaultRoute
 		) {
-			return () => {};
+			return () => { };
 		}
 		return close;
 	}
 
-	filterBehviors( behaviors ) {
-		if ( this.isEhpDocument() && this.notElementorDomain() ) {
+	filterBehviors(behaviors) {
+		if (this.isEhpDocument() && this.notElementorDomain()) {
 			const { contextMenu: { groups } } = behaviors;
 			behaviors.contextMenu.groups = groups
-				.map( this.filterOutUnsupportedActions() )
-				.filter( ( group ) => group.actions.length );
+				.map(this.filterOutUnsupportedActions())
+				.filter((group) => group.actions.length);
 		}
 		return behaviors;
 	}
 
 	notElementorDomain() {
-		return ! ehpTemplatePartsEditorSettings.isElementorDomain;
+		return !ehpTemplatePartsEditorSettings.isElementorDomain;
 	}
 
-	setSourceAsRemote( isRemote, activeSource ) {
-		if ( 'remote-ehp' === activeSource ) {
+	setSourceAsRemote(isRemote, activeSource) {
+		if ('remote-ehp' === activeSource) {
 			return true;
 		}
 
@@ -59,17 +59,19 @@ export default class TemplatesModule extends elementorModules.editor.utils.Modul
 	}
 
 	redirectToHelloPlus() {
-		$e.internal( 'document/save/set-is-modified', { status: false } );
-		window.location.href = elementor.config.close_modal_redirect_hello_plus + elementor.config.document.type;
+		if (this.notElementorDomain()) {
+			$e.internal('document/save/set-is-modified', { status: false });
+			window.location.href = elementor.config.close_modal_redirect_hello_plus + elementor.config.document.type;
+		}
 	}
 
 	async openSiteIdentity() {
-		await $e.run( 'panel/global/open' );
-		$e.route( 'panel/global/settings-site-identity' );
+		await $e.run('panel/global/open');
+		$e.route('panel/global/settings-site-identity');
 	}
 
-	resetCommonControls( commonControls, widgetType ) {
-		if ( [ 'ehp-footer', 'ehp-header' ].includes( widgetType ) ) {
+	resetCommonControls(commonControls, widgetType) {
+		if (['ehp-footer', 'ehp-header'].includes(widgetType)) {
 			return null;
 		}
 
@@ -77,20 +79,20 @@ export default class TemplatesModule extends elementorModules.editor.utils.Modul
 	}
 
 	filterOutUnsupportedActions() {
-		return ( group ) => {
+		return (group) => {
 			const enabledCommands = elementor.helpers.hasPro()
-				? [ 'edit', 'delete', 'resetStyle' ]
-				: [ 'edit', 'delete', 'resetStyle', 'save' ];
+				? ['edit', 'delete', 'resetStyle']
+				: ['edit', 'delete', 'resetStyle', 'save'];
 			const { name, actions } = group;
 
 			return {
 				name,
-				actions: actions.filter( ( action ) => enabledCommands.includes( action.name ) ),
+				actions: actions.filter((action) => enabledCommands.includes(action.name)),
 			};
 		};
 	}
 
 	isEhpDocument() {
-		return [ 'ehp-footer', 'ehp-header' ].includes( elementor.config.document.type );
+		return ['ehp-footer', 'ehp-header'].includes(elementor.config.document.type);
 	}
 }

--- a/modules/template-parts/assets/js/editor/module.js
+++ b/modules/template-parts/assets/js/editor/module.js
@@ -37,17 +37,22 @@ export default class TemplatesModule extends elementorModules.editor.utils.Modul
 	}
 
 	filterBehviors( behaviors ) {
-		if ( this.isEhpDocument() && this.notElementorDomain() ) {
+		if ( this.isElementorDomain() ) {
+			return behaviors;
+		}
+
+		if ( this.isEhpDocument() ) {
 			const { contextMenu: { groups } } = behaviors;
 			behaviors.contextMenu.groups = groups
 				.map( this.filterOutUnsupportedActions() )
 				.filter( ( group ) => group.actions.length );
 		}
+
 		return behaviors;
 	}
 
-	notElementorDomain() {
-		return ! ehpTemplatePartsEditorSettings.isElementorDomain;
+	isElementorDomain() {
+		return ehpTemplatePartsEditorSettings.isElementorDomain;
 	}
 
 	setSourceAsRemote( isRemote, activeSource ) {
@@ -59,7 +64,7 @@ export default class TemplatesModule extends elementorModules.editor.utils.Modul
 	}
 
 	redirectToHelloPlus() {
-		if ( ! this.notElementorDomain() ) {
+		if ( this.isElementorDomain() ) {
 			return;
 		}
 

--- a/modules/template-parts/assets/js/editor/module.js
+++ b/modules/template-parts/assets/js/editor/module.js
@@ -2,15 +2,15 @@ import Component from './component';
 
 export default class TemplatesModule extends elementorModules.editor.utils.Module {
 	onElementorInit() {
-		$e.components.register(new Component({ manager: this }));
-		elementor.channels.editor.on('helloPlusLogo:change', this.openSiteIdentity);
-		elementor.hooks.addFilter('elements/widget/controls/common/default', this.resetCommonControls.bind(this));
-		elementor.hooks.addFilter('elements/widget/controls/common-optimized/default', this.resetCommonControls.bind(this));
-		elementor.hooks.addFilter('templates/source/is-remote', this.setSourceAsRemote.bind(this));
-		elementor.hooks.addFilter('elements/base/behaviors', this.filterBehviors.bind(this), 1000);
+		$e.components.register( new Component( { manager: this } ) );
+		elementor.channels.editor.on( 'helloPlusLogo:change', this.openSiteIdentity );
+		elementor.hooks.addFilter( 'elements/widget/controls/common/default', this.resetCommonControls.bind( this ) );
+		elementor.hooks.addFilter( 'elements/widget/controls/common-optimized/default', this.resetCommonControls.bind( this ) );
+		elementor.hooks.addFilter( 'templates/source/is-remote', this.setSourceAsRemote.bind( this ) );
+		elementor.hooks.addFilter( 'elements/base/behaviors', this.filterBehviors.bind( this ), 1000 );
 		elementor.hooks.addFilter(
 			'component/modal/close',
-			this.preventClosingModal.bind(this),
+			this.preventClosingModal.bind( this ),
 			1000,
 		);
 
@@ -19,14 +19,14 @@ export default class TemplatesModule extends elementorModules.editor.utils.Modul
 			'core/modal/close/ehp-header',
 		];
 
-		types.forEach((type) => {
-			window.addEventListener(type, this.redirectToHelloPlus);
-		});
+		types.forEach( ( type ) => {
+			window.addEventListener( type, this.redirectToHelloPlus );
+		} );
 
 		window.templatesModule = this;
 	}
 
-	preventClosingModal(close, component) {
+	preventClosingModal( close, component ) {
 		if (
 			'library' === component.getNamespace() &&
 			'library/templates/ehp-elements' === component?.defaultRoute
@@ -36,22 +36,22 @@ export default class TemplatesModule extends elementorModules.editor.utils.Modul
 		return close;
 	}
 
-	filterBehviors(behaviors) {
-		if (this.isEhpDocument() && this.notElementorDomain()) {
+	filterBehviors( behaviors ) {
+		if ( this.isEhpDocument() && this.notElementorDomain() ) {
 			const { contextMenu: { groups } } = behaviors;
 			behaviors.contextMenu.groups = groups
-				.map(this.filterOutUnsupportedActions())
-				.filter((group) => group.actions.length);
+				.map( this.filterOutUnsupportedActions() )
+				.filter( ( group ) => group.actions.length );
 		}
 		return behaviors;
 	}
 
 	notElementorDomain() {
-		return !ehpTemplatePartsEditorSettings.isElementorDomain;
+		return ! ehpTemplatePartsEditorSettings.isElementorDomain;
 	}
 
-	setSourceAsRemote(isRemote, activeSource) {
-		if ('remote-ehp' === activeSource) {
+	setSourceAsRemote( isRemote, activeSource ) {
+		if ( 'remote-ehp' === activeSource ) {
 			return true;
 		}
 
@@ -59,19 +59,19 @@ export default class TemplatesModule extends elementorModules.editor.utils.Modul
 	}
 
 	redirectToHelloPlus() {
-		if (this.notElementorDomain()) {
-			$e.internal('document/save/set-is-modified', { status: false });
+		if ( this.notElementorDomain() ) {
+			$e.internal( 'document/save/set-is-modified', { status: false } );
 			window.location.href = elementor.config.close_modal_redirect_hello_plus + elementor.config.document.type;
 		}
 	}
 
 	async openSiteIdentity() {
-		await $e.run('panel/global/open');
-		$e.route('panel/global/settings-site-identity');
+		await $e.run( 'panel/global/open' );
+		$e.route( 'panel/global/settings-site-identity' );
 	}
 
-	resetCommonControls(commonControls, widgetType) {
-		if (['ehp-footer', 'ehp-header'].includes(widgetType)) {
+	resetCommonControls( commonControls, widgetType ) {
+		if ( [ 'ehp-footer', 'ehp-header' ].includes( widgetType ) ) {
 			return null;
 		}
 
@@ -79,20 +79,20 @@ export default class TemplatesModule extends elementorModules.editor.utils.Modul
 	}
 
 	filterOutUnsupportedActions() {
-		return (group) => {
+		return ( group ) => {
 			const enabledCommands = elementor.helpers.hasPro()
-				? ['edit', 'delete', 'resetStyle']
-				: ['edit', 'delete', 'resetStyle', 'save'];
+				? [ 'edit', 'delete', 'resetStyle' ]
+				: [ 'edit', 'delete', 'resetStyle', 'save' ];
 			const { name, actions } = group;
 
 			return {
 				name,
-				actions: actions.filter((action) => enabledCommands.includes(action.name)),
+				actions: actions.filter( ( action ) => enabledCommands.includes( action.name ) ),
 			};
 		};
 	}
 
 	isEhpDocument() {
-		return ['ehp-footer', 'ehp-header'].includes(elementor.config.document.type);
+		return [ 'ehp-footer', 'ehp-header' ].includes( elementor.config.document.type );
 	}
 }

--- a/modules/template-parts/widgets/ehp-widget-base.php
+++ b/modules/template-parts/widgets/ehp-widget-base.php
@@ -35,7 +35,10 @@ abstract class Ehp_Widget_Base extends Widget_Base {
 	}
 
 	public function show_in_panel(): bool {
-		return apply_filters( 'hello-plus/template-parts/widgets/panel/show', false );
+		return apply_filters(
+			'hello-plus/template-parts/widgets/panel/show',
+			Theme_Utils::are_we_on_elementor_domains()
+		);
 	}
 
 	public function hide_on_search(): bool {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Enables visibility control of template part widgets in Elementor's editor based on domain context.

Main changes:
- Refactors domain check with new positive isElementorDomain() method replacing notElementorDomain()
- Adds conditional check to prevent redirectToHelloPlus() when on Elementor domains
- Updates show_in_panel() to conditionally display widgets on Elementor domains

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
