### PR TITLE
Fix: Do not show common controls for Flex footer. Show container on library [TMZ-743] [TMZ-739]

### DIFF
--- a/modules/template-parts/assets/js/editor/hooks/ui/select.js
+++ b/modules/template-parts/assets/js/editor/hooks/ui/select.js
@@ -13,6 +13,10 @@ export class SelectAfterContainer extends $e.modules.hookUI.After {
 			type = args?.containers[ 0 ]?.document?.config?.type;
 		}
 
+		if ( ehpTemplatePartsEditorSettings.isElementorDomain ) {
+			return false;
+		}
+
 		return [ 'ehp-header', 'ehp-footer' ].includes( type );
 	}
 

--- a/modules/template-parts/assets/js/editor/hooks/ui/select.js
+++ b/modules/template-parts/assets/js/editor/hooks/ui/select.js
@@ -13,7 +13,7 @@ export class SelectAfterContainer extends $e.modules.hookUI.After {
 			type = args?.containers[ 0 ]?.document?.config?.type;
 		}
 
-		if ( ehpTemplatePartsEditorSettings.isElementorDomain ) {
+		if ( ehpTemplatePartsEditorSettings?.isElementorDomain ) {
 			return false;
 		}
 

--- a/modules/template-parts/assets/js/editor/module.js
+++ b/modules/template-parts/assets/js/editor/module.js
@@ -52,7 +52,7 @@ export default class TemplatesModule extends elementorModules.editor.utils.Modul
 	}
 
 	isElementorDomain() {
-		return ehpTemplatePartsEditorSettings.isElementorDomain;
+		return ehpTemplatePartsEditorSettings?.isElementorDomain;
 	}
 
 	setSourceAsRemote( isRemote, activeSource ) {

--- a/modules/template-parts/assets/js/editor/module.js
+++ b/modules/template-parts/assets/js/editor/module.js
@@ -78,7 +78,7 @@ export default class TemplatesModule extends elementorModules.editor.utils.Modul
 	}
 
 	resetCommonControls( commonControls, widgetType ) {
-		if ( [ 'ehp-footer', 'ehp-header' ].includes( widgetType ) ) {
+		if ( [ 'ehp-footer', 'ehp-header', 'ehp-flex-footer' ].includes( widgetType ) ) {
 			return null;
 		}
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add conditional check for Elementor domain in UI hooks and extend widget type support for template parts.

Main changes:
- Skip selection prevention logic when on Elementor domain with optional chaining
- Add support for 'ehp-flex-footer' widget type to resetCommonControls function
- Add null check using optional chaining for ehpTemplatePartsEditorSettings in isElementorDomain method

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
