### PR TITLE
Internal: Allow users to override whether the plugin should behave as on the client or on the library [TMZ-742]

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -29,8 +29,8 @@ class Utils {
 
 		foreach ( $allowed_domains as $domain ) {
 			if ( str_ends_with( $current_domain, $domain ) ) {
-                                $is_elementor_domain = true;
-                                break;
+								$is_elementor_domain = true;
+								break;
 			}
 		}
 

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -25,12 +25,15 @@ class Utils {
 			'elementor.red',
 		];
 
+		$is_elementor_domain = false;
+
 		foreach ( $allowed_domains as $domain ) {
 			if ( str_ends_with( $current_domain, $domain ) ) {
-				return true;
+				$is_elementor_domain = true;
 			}
 		}
-		return false;
+
+		return apply_filters( 'hello-plus/utils/are_we_on_elementor_domains', $is_elementor_domain );
 	}
 
 	public static function has_hello_biz(): bool {

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -29,7 +29,8 @@ class Utils {
 
 		foreach ( $allowed_domains as $domain ) {
 			if ( str_ends_with( $current_domain, $domain ) ) {
-				$is_elementor_domain = true;
+                                $is_elementor_domain = true;
+                                break;
 			}
 		}
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add filter hook to allow overriding domain detection behavior in the Hello Plus plugin.
Main changes:
- Implemented filter hook 'hello-plus/utils/are_we_on_elementor_domains' for domain detection override
- Restructured domain validation logic to store result in a variable instead of early returns

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
