### PR TITLE
Internal: Update controls specificity [TMZ-783]

### DIFF
--- a/modules/content/classes/render/widget-contact-render.php
+++ b/modules/content/classes/render/widget-contact-render.php
@@ -126,6 +126,8 @@ class Widget_Contact_Render {
 			</div>
 			<div <?php $this->widget->print_render_attribute_string( 'groups' ); ?>>
 				<?php
+					$this->widget->add_render_attribute( 'group', 'class', self::LAYOUT_CLASSNAME . '__group' );
+
 					$this->render_contact_group( '1' );
 
 				if ( 'yes' === $this->settings['group_2_switcher'] ) {
@@ -145,7 +147,7 @@ class Widget_Contact_Render {
 
 	protected function render_contact_group( $group_number ) {
 		$group_type = $this->settings[ 'group_' . $group_number . '_type' ];
-		$this->widget->add_render_attribute( 'group', 'class', self::LAYOUT_CLASSNAME . '__group' );
+
 		?>
 		<div <?php $this->widget->print_render_attribute_string( 'group' ); ?>>
 			<?php

--- a/modules/content/widgets/contact.php
+++ b/modules/content/widgets/contact.php
@@ -945,7 +945,7 @@ class Contact extends Widget_Base {
 					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
-					'{{WRAPPER}} .ehp-contact' => '--contact-text-heading-color: {{VALUE}}',
+					'{{WRAPPER}} .ehp-contact .ehp-contact__heading' => 'color: {{VALUE}};',
 				],
 			]
 		);
@@ -1050,7 +1050,7 @@ class Contact extends Widget_Base {
 					'default' => Global_Colors::COLOR_SECONDARY,
 				],
 				'selectors' => [
-					'{{WRAPPER}} .ehp-contact' => '--contact-group-subheading-color: {{VALUE}}',
+					'{{WRAPPER}} .ehp-contact .ehp-contact__groups .ehp-contact__subheading' => 'color: {{VALUE}};',
 				],
 			]
 		);

--- a/modules/content/widgets/cta.php
+++ b/modules/content/widgets/cta.php
@@ -457,7 +457,7 @@ class CTA extends Widget_Base {
 					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
-					'{{WRAPPER}} .ehp-cta' => '--cta-heading-color: {{VALUE}}',
+					'{{WRAPPER}} .ehp-cta .ehp-cta__heading' => 'color: {{VALUE}};',
 				],
 			]
 		);
@@ -491,7 +491,7 @@ class CTA extends Widget_Base {
 					'default' => Global_Colors::COLOR_TEXT,
 				],
 				'selectors' => [
-					'{{WRAPPER}} .ehp-cta' => '--cta-description-color: {{VALUE}}',
+					'{{WRAPPER}} .ehp-cta .ehp-cta__description' => 'color: {{VALUE}};',
 				],
 			]
 		);

--- a/modules/content/widgets/flex-hero.php
+++ b/modules/content/widgets/flex-hero.php
@@ -470,7 +470,7 @@ class Flex_Hero extends Widget_Base {
 					'default' => Global_Colors::COLOR_TEXT,
 				],
 				'selectors' => [
-					'{{WRAPPER}} .ehp-flex-hero' => '--flex-hero-intro-color: {{VALUE}}',
+					'{{WRAPPER}} .ehp-flex-hero .ehp-flex-hero__intro' => 'color: {{VALUE}};',
 				],
 			]
 		);
@@ -504,7 +504,7 @@ class Flex_Hero extends Widget_Base {
 					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
-					'{{WRAPPER}} .ehp-flex-hero' => '--flex-hero-heading-color: {{VALUE}}',
+					'{{WRAPPER}} .ehp-flex-hero .ehp-flex-hero__heading' => 'color: {{VALUE}};',
 				],
 			]
 		);
@@ -538,7 +538,7 @@ class Flex_Hero extends Widget_Base {
 					'default' => Global_Colors::COLOR_SECONDARY,
 				],
 				'selectors' => [
-					'{{WRAPPER}} .ehp-flex-hero' => '--flex-hero-subheading-color: {{VALUE}}',
+					'{{WRAPPER}} .ehp-flex-hero .ehp-flex-hero__subheading' => 'color: {{VALUE}};',
 				],
 			]
 		);

--- a/modules/content/widgets/zig-zag.php
+++ b/modules/content/widgets/zig-zag.php
@@ -472,7 +472,7 @@ class Zig_Zag extends Widget_Base {
 					'default' => Global_Colors::COLOR_SECONDARY,
 				],
 				'selectors' => [
-					'{{WRAPPER}} .ehp-zigzag' => '--zigzag-title-color: {{VALUE}}',
+					'{{WRAPPER}} .ehp-zigzag .ehp-zigzag__title' => 'color: {{VALUE}};',
 				],
 			]
 		);


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update CSS selectors from custom properties to direct element targeting for improved specificity in widget controls.

Main changes:
- Changed Contact, CTA, Flex-Hero and Zig-Zag widgets to use direct element selectors instead of CSS variables
- Moved contact group render attribute initialization outside render_contact_group method to prevent duplication
- Improved color control targeting by applying styles directly to specific elements

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
