### PR TITLE
Internal: Update cherry pick PR format for Jira compatibility [TMZ-822]

### DIFF
--- a/.github/workflows/cherry-pick-pr.yml
+++ b/.github/workflows/cherry-pick-pr.yml
@@ -244,13 +244,13 @@ jobs:
                 TRUNCATED_CONTENT="$PR_TITLE_WITHOUT_TICKETS"
               fi
               
-              # Add tickets back at the end
-              TRUNCATED_TITLE="${TRUNCATED_CONTENT} ${PR_TICKETS}"
+              # Add suffix first, then tickets at the end for Jira compatibility
+              TRUNCATED_TITLE="${TRUNCATED_CONTENT}${SUFFIX} ${PR_TICKETS}"
 
               gh pr create \
                 --base "$TARGET" \
                 --head "$BRANCH" \
-                --title "${TRUNCATED_TITLE}${SUFFIX}" \
+                --title "${TRUNCATED_TITLE}" \
                 --body "Automatic cherry-pick of [#${PR_NUMBER}](${ORIG_URL}) to \`${TARGET}\` branch.
 
                 **Plugin Information:**


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update cherry-pick PR title format to ensure Jira compatibility by changing the order of ticket identifiers in PR titles.
Main changes:
- Repositioned PR ticket identifiers to appear after the suffix instead of before it
- Updated comment to clarify the change is for Jira compatibility
- Modified title formatting in GitHub PR creation command to match new structure

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
