### PR TITLE
Internal: Remove the cherry pick PR title truncation [TMZ-822]

### DIFF
--- a/.github/workflows/cherry-pick-pr.yml
+++ b/.github/workflows/cherry-pick-pr.yml
@@ -224,10 +224,20 @@ jobs:
                 **Trigger:** Label \`${LABEL_NAME}\` added to closed PR"
               fi
 
+              # Extract tickets and add to title for Jira compatibility
+              PR_TICKETS=$(echo "$PR_TITLE" | grep -o '\[[A-Z]\{2,\}-[0-9]\+\]' | tr '\n' ' ' | sed 's/[[:space:]]*$//')
+              
+              # Create title with tickets at the end
+              if [ -n "$PR_TICKETS" ]; then
+                CHERRY_PICK_TITLE="$PR_TITLE (🍒 CP #${PR_NUMBER}→${TARGET}) ${PR_TICKETS}"
+              else
+                CHERRY_PICK_TITLE="$PR_TITLE (🍒 CP #${PR_NUMBER}→${TARGET})"
+              fi
+
               gh pr create \
                 --base "$TARGET" \
                 --head "$BRANCH" \
-                --title "$PR_TITLE (🍒 CP #${PR_NUMBER}→${TARGET})" \
+                --title "$CHERRY_PICK_TITLE" \
                 --body "Automatic cherry-pick of [#${PR_NUMBER}](${ORIG_URL}) to \`${TARGET}\` branch.
 
                 **Plugin Information:**

--- a/.github/workflows/cherry-pick-pr.yml
+++ b/.github/workflows/cherry-pick-pr.yml
@@ -224,33 +224,10 @@ jobs:
                 **Trigger:** Label \`${LABEL_NAME}\` added to closed PR"
               fi
 
-              # Set maximum title length (GitHub recommended: 72 chars)
-              MAX_TITLE_LENGTH=72
-              SUFFIX=" (🍒 CP #${PR_NUMBER}→${TARGET})"
-              SUFFIX_LENGTH=${#SUFFIX}
-              
-              # Extract tickets and remove from content for truncation
-              PR_TICKETS=$(echo "$PR_TITLE" | grep -o '\[[A-Z]\{2,\}-[0-9]\+\]' | tr '\n' ' ' | sed 's/[[:space:]]*$//')
-              PR_TITLE_WITHOUT_TICKETS=$(echo "$PR_TITLE" | sed 's/\[[A-Z]\{2,\}-[0-9]\+\]//g' | sed 's/[[:space:]]*$//')
-              
-              # Reserve 10 characters for ticket number (including space)
-              TICKET_RESERVED_LENGTH=10
-              MAX_PR_TITLE_LENGTH=$((MAX_TITLE_LENGTH - SUFFIX_LENGTH - TICKET_RESERVED_LENGTH))
-
-              # Truncate content and add tickets back
-              if [ ${#PR_TITLE_WITHOUT_TICKETS} -gt $MAX_PR_TITLE_LENGTH ]; then
-                TRUNCATED_CONTENT="${PR_TITLE_WITHOUT_TICKETS:0:$((MAX_PR_TITLE_LENGTH - 3))}..."
-              else
-                TRUNCATED_CONTENT="$PR_TITLE_WITHOUT_TICKETS"
-              fi
-              
-              # Add suffix first, then tickets at the end for Jira compatibility
-              TRUNCATED_TITLE="${TRUNCATED_CONTENT}${SUFFIX} ${PR_TICKETS}"
-
               gh pr create \
                 --base "$TARGET" \
                 --head "$BRANCH" \
-                --title "${TRUNCATED_TITLE}" \
+                --title "$PR_TITLE (🍒 CP #${PR_NUMBER}→${TARGET})" \
                 --body "Automatic cherry-pick of [#${PR_NUMBER}](${ORIG_URL}) to \`${TARGET}\` branch.
 
                 **Plugin Information:**


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Remove title truncation from cherry-pick PR workflow while preserving ticket information for Jira compatibility.

Main changes:
- Removed code that truncates PR titles to 72 characters in the cherry-pick workflow
- Simplified title formatting to preserve the complete original PR title with cherry-pick indicators
- Maintained Jira ticket references at the end of PR title for compatibility

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
