### PR TITLE
Fix: Remove interaction between forms lite and pro [TMZ-832]

### DIFF
--- a/modules/forms/fields/acceptance.php
+++ b/modules/forms/fields/acceptance.php
@@ -1,10 +1,6 @@
 <?php
 namespace HelloPlus\Modules\Forms\Fields;
 
-use Elementor\Controls_Manager;
-use HelloPlus\Includes\Utils;
-use HelloPlus\Plugin;
-
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
@@ -17,44 +13,6 @@ class Acceptance extends Field_Base {
 
 	public function get_name() {
 		return esc_html__( 'Acceptance', 'hello-plus' );
-	}
-
-	public function update_controls( $widget ) {
-		$elementor = Utils::elementor();
-
-		$control_data = $elementor->controls_manager->get_control_from_stack( $widget->get_unique_name(), 'form_fields' );
-
-		if ( is_wp_error( $control_data ) ) {
-			return;
-		}
-
-		$field_controls = [
-			'acceptance_text' => [
-				'name' => 'acceptance_text',
-				'label' => esc_html__( 'Acceptance Text', 'hello-plus' ),
-				'type' => Controls_Manager::TEXTAREA,
-				'condition' => [
-					'field_type' => $this->get_type(),
-				],
-				'tab' => 'content',
-				'inner_tab' => 'form_fields_content_tab',
-				'tabs_wrapper' => 'form_fields_tabs',
-			],
-			'checked_by_default' => [
-				'name' => 'checked_by_default',
-				'label' => esc_html__( 'Checked by Default', 'hello-plus' ),
-				'type' => Controls_Manager::SWITCHER,
-				'condition' => [
-					'field_type' => $this->get_type(),
-				],
-				'tab' => 'content',
-				'inner_tab' => 'form_fields_content_tab',
-				'tabs_wrapper' => 'form_fields_tabs',
-			],
-		];
-
-		$control_data['fields'] = $this->inject_field_controls( $control_data['fields'], $field_controls );
-		$widget->update_control( 'form_fields', $control_data );
 	}
 
 	public function render( $item, $item_index, $form ) {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Remove form field control integration between Forms Lite and Pro modules to eliminate module interdependencies.
Main changes:
- Removed update_controls method that was injecting field controls from Pro to Lite version
- Eliminated unnecessary imports of Controls_Manager and other Pro-specific dependencies
- Preserved core field rendering functionality while removing integration points

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
