### PR TITLE
Fix: Do not trigger elementor onboarding, header alignment [TMZ-837] [TMZ-835]

### DIFF
--- a/modules/admin/classes/ajax/setup-wizard.php
+++ b/modules/admin/classes/ajax/setup-wizard.php
@@ -29,10 +29,12 @@ class Setup_Wizard {
 
 		switch ( $step ) {
 			case 'install-elementor':
+				add_option( 'elementor_onboarded', true );
 				$step = new Install_Elementor();
 				$step->install_and_activate();
 				break;
 			case 'activate-elementor':
+				add_option( 'elementor_onboarded', true );
 				$step = new Install_Elementor();
 				$step->activate();
 				break;

--- a/modules/template-parts/assets/scss/hello-plus-header.scss
+++ b/modules/template-parts/assets/scss/hello-plus-header.scss
@@ -728,6 +728,13 @@
 					display: flex;
 					flex-direction: column;
 
+					&.has-responsive-width-stretch {
+						& .ehp-header__contact-buttons.has-responsive-display-dropdown {
+							padding-inline-start: var(--header-box-padding-inline-start);
+							padding-inline-end: var(--header-box-padding-inline-end);
+						}
+					}
+
 					&.has-responsive-width-default {
 						padding-inline-start: var(--header-box-padding-inline-start);
 						padding-inline-end: var(--header-box-padding-inline-end);
@@ -778,15 +785,6 @@
 							border-bottom: none;
 							padding-bottom: 0;
 						}
-					}
-				}
-			}
-
-			&__ctas-container {
-				&.has-responsive-width-stretch {
-					& .ehp-header__contact-buttons.has-responsive-display-dropdown {
-						padding-inline-start: var(--header-box-padding-inline-start);
-						padding-inline-end: var(--header-box-padding-inline-end);
 					}
 				}
 			}

--- a/modules/template-parts/assets/scss/hello-plus-header.scss
+++ b/modules/template-parts/assets/scss/hello-plus-header.scss
@@ -727,6 +727,11 @@
 					align-items: stretch;
 					display: flex;
 					flex-direction: column;
+
+					&.has-responsive-width-default {
+						padding-inline-start: var(--header-box-padding-inline-start);
+						padding-inline-end: var(--header-box-padding-inline-end);
+					}	
 				}
 
 				.ehp-header__contact-buttons.has-responsive-display-navbar {
@@ -778,11 +783,6 @@
 			}
 
 			&__ctas-container {
-				&.has-responsive-width-default {
-					padding-inline-start: var(--header-box-padding-inline-start);
-					padding-inline-end: var(--header-box-padding-inline-end);
-				}
-
 				&.has-responsive-width-stretch {
 					& .ehp-header__contact-buttons.has-responsive-display-dropdown {
 						padding-inline-start: var(--header-box-padding-inline-start);


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix Elementor onboarding wizard interruption and correct header alignment issues in responsive layouts.
Main changes:
- Added option to skip Elementor onboarding when installing/activating through setup wizard
- Moved header CSS padding rules to correct responsive breakpoint for proper alignment
- Fixed padding inconsistencies for CTA container in different responsive display modes

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
